### PR TITLE
Wnw 118 attack sfx should be interrupted

### DIFF
--- a/Drawn to Death/Assets/Prefabs/Doodle Bars.prefab
+++ b/Drawn to Death/Assets/Prefabs/Doodle Bars.prefab
@@ -314,13 +314,14 @@ MonoBehaviour:
   attackCooldown: 100
   attackDistance: -1
   slowdownFactor: 3
+  moving: 1
   targetSeeker: {fileID: 8639319312470385590}
   playerSeeker: {fileID: 4189887901981635619}
   seekDistance: 20
   nextWaypointDistance: 1
   blockers: []
   deathSfx: 
-  attackSfx: 
+  attackSfx: event:/CrabAttack
   slowed: 0
   lifestealing: 0
   slowDuration: 0

--- a/Drawn to Death/Assets/Scripts/EnemyScripts/Cubie.cs
+++ b/Drawn to Death/Assets/Scripts/EnemyScripts/Cubie.cs
@@ -69,7 +69,9 @@ public class Cubie : EnemyAI
         //Start the attack
         if (target != null && attackTimer.IsUseable())
         {
-            FMODUnity.RuntimeManager.PlayOneShot("event:/CubieAttack");
+            // play the attack sfx
+            attackSFXInstance.start();
+            
             createdProjectile = false;
             windupTimer.StartTimer();
             attackTimer.StartTimer();

--- a/Drawn to Death/Assets/Scripts/EnemyScripts/DoodleCrab.cs
+++ b/Drawn to Death/Assets/Scripts/EnemyScripts/DoodleCrab.cs
@@ -40,8 +40,8 @@ public class DoodleCrab : EnemyAI
     {
         if (target != null && attackTimer.IsUseable())
         {
-            //Play the FMOD event correlating to the attack
-            FMODUnity.RuntimeManager.PlayOneShot(attackSfx);
+            // play the attack sfx
+            attackSFXInstance.start();
             
             //Lunge at the target
             Vector2 direction = ((Vector2)target.position - rb.position).normalized;

--- a/Drawn to Death/Assets/Scripts/EnemyScripts/EnemyAI.cs
+++ b/Drawn to Death/Assets/Scripts/EnemyScripts/EnemyAI.cs
@@ -38,6 +38,8 @@ public abstract class EnemyAI : MonoBehaviour
     [Header("Music and sound")]
     public string deathSfx;
     public string attackSfx;
+
+    protected FMOD.Studio.EventInstance attackSFXInstance;
     
     [Header("Effects")]
     public bool slowed = false;
@@ -112,6 +114,8 @@ public abstract class EnemyAI : MonoBehaviour
         target = player.transform;
         health = maxHealth;
         healthBar.SetHealth(health, maxHealth);
+        attackSFXInstance = FMODUnity.RuntimeManager.CreateInstance(attackSfx);
+        FMODUnity.RuntimeManager.AttachInstanceToGameObject(attackSFXInstance, GetComponent<Transform>(), GetComponent<Rigidbody2D>());
       
 
         //Create Timers
@@ -344,6 +348,7 @@ public abstract class EnemyAI : MonoBehaviour
                             animator.SetBool("attacking", false);
                             animator.SetBool("chasing", true);
                             state = State.chase;
+                            attackSFXInstance.stop(0);
                             return;
                         }
                     }
@@ -356,6 +361,9 @@ public abstract class EnemyAI : MonoBehaviour
                 }
             case State.dying:
                 {
+                    // If attack sfx is playing, stop it
+                    attackSFXInstance.stop(0);
+
                     //dying Behaviour
                     animationTimer += Time.deltaTime;
                     selfImage.color = Color.white;
@@ -481,7 +489,7 @@ public abstract class EnemyAI : MonoBehaviour
     //Kill this entity
     virtual public void Kill()
     {
-        // Play the FMOD event correlating to the death
+        // Play the death sfx
         FMODUnity.RuntimeManager.PlayOneShot(deathSfx, this.transform.position);
         
         //Set State
@@ -580,6 +588,8 @@ public abstract class EnemyAI : MonoBehaviour
 
          
             Stun();
+
+            attackSFXInstance.stop(0);
         }
 
         return;
@@ -588,6 +598,9 @@ public abstract class EnemyAI : MonoBehaviour
 
     virtual public void Stun()
     {
+        // Stop Attack sfx if playing
+        attackSFXInstance.stop(0);
+
         if (!attackTimer.IsOnCooldown())
         {
             attackTimer.StartCooldown(attackCooldown * 0.7f);

--- a/Drawn to Death/Assets/Scripts/EnemyScripts/OodleKnight.cs
+++ b/Drawn to Death/Assets/Scripts/EnemyScripts/OodleKnight.cs
@@ -14,6 +14,8 @@ public class OodleKnight : EnemyAI
     private CooldownTimer windupTimer;
     private KnightAttack attackObject;
 
+    private FMOD.Studio.EventInstance fmodInstance;
+
     override protected void Start()
     {
         //Override variables
@@ -27,6 +29,10 @@ public class OodleKnight : EnemyAI
         //Coolect Object references
         attackObject = GetComponentInChildren<KnightAttack>();
         if (attackObject == null) Debug.LogError("Error - " + gameObject.name + " is missing reference to an Attack Object");
+
+        // Create FMOD instance for attack SFX
+        fmodInstance = FMODUnity.RuntimeManager.CreateInstance("event:/OodleKnightAttack");  
+        FMODUnity.RuntimeManager.AttachInstanceToGameObject(fmodInstance, GetComponent<Transform>(), GetComponent<Rigidbody2D>());
 
         //Continue with the base class implementation of Start
         base.Start();
@@ -74,6 +80,7 @@ public class OodleKnight : EnemyAI
         //Try to get into position to attack the target
         if (!attackTimer.IsActive())
         {
+            fmodInstance.stop(0);
             animator.SetBool("attacking", false);
             animator.SetBool("chasing", true);
 
@@ -118,7 +125,7 @@ public class OodleKnight : EnemyAI
             //Start the attack
             if (target != null && state == State.attack && attackTimer.IsUseable() && collision.gameObject.transform == target)
             {
-                FMODUnity.RuntimeManager.PlayOneShot("event:/OodleKnightAttack", this.transform.position);
+                fmodInstance.start();
 
                 windupTimer.StartTimer();
                 attackTimer.StartTimer();

--- a/Drawn to Death/Assets/Scripts/EnemyScripts/OodleKnight.cs
+++ b/Drawn to Death/Assets/Scripts/EnemyScripts/OodleKnight.cs
@@ -14,8 +14,6 @@ public class OodleKnight : EnemyAI
     private CooldownTimer windupTimer;
     private KnightAttack attackObject;
 
-    private FMOD.Studio.EventInstance fmodInstance;
-
     override protected void Start()
     {
         //Override variables
@@ -29,10 +27,6 @@ public class OodleKnight : EnemyAI
         //Coolect Object references
         attackObject = GetComponentInChildren<KnightAttack>();
         if (attackObject == null) Debug.LogError("Error - " + gameObject.name + " is missing reference to an Attack Object");
-
-        // Create FMOD instance for attack SFX
-        fmodInstance = FMODUnity.RuntimeManager.CreateInstance("event:/OodleKnightAttack");  
-        FMODUnity.RuntimeManager.AttachInstanceToGameObject(fmodInstance, GetComponent<Transform>(), GetComponent<Rigidbody2D>());
 
         //Continue with the base class implementation of Start
         base.Start();
@@ -80,7 +74,6 @@ public class OodleKnight : EnemyAI
         //Try to get into position to attack the target
         if (!attackTimer.IsActive())
         {
-            fmodInstance.stop(0);
             animator.SetBool("attacking", false);
             animator.SetBool("chasing", true);
 
@@ -125,7 +118,8 @@ public class OodleKnight : EnemyAI
             //Start the attack
             if (target != null && state == State.attack && attackTimer.IsUseable() && collision.gameObject.transform == target)
             {
-                fmodInstance.start();
+                // start the attack sfx
+                attackSFXInstance.start();
 
                 windupTimer.StartTimer();
                 attackTimer.StartTimer();


### PR DESCRIPTION
Changes: 
- Attack SFX is now an FMOD instance inside the Enemy AI script
- All enemy scripts inheriting EnemyAI will start the attack SFX instance within their Attack() method
- Attack SFX instance will be stopped if the Stun() function is called, or if the enemy enters the "dying" state