### PR TITLE
Ability timers

### DIFF
--- a/Drawn to Death/Assets/Level 1.unity
+++ b/Drawn to Death/Assets/Level 1.unity
@@ -9212,6 +9212,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7246638093219242156, guid: 34d9b55fa170a444bb86050513388636,
+        type: 3}
+      propertyPath: playerIndicator
+      value: 
+      objectReference: {fileID: 2462823223096369255}
     - target: {fileID: 7298473912298103450, guid: 34d9b55fa170a444bb86050513388636,
         type: 3}
       propertyPath: m_AnchorMax.y

--- a/Drawn to Death/Assets/Level 2.unity
+++ b/Drawn to Death/Assets/Level 2.unity
@@ -13955,6 +13955,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7246638093219242156, guid: 34d9b55fa170a444bb86050513388636,
+        type: 3}
+      propertyPath: playerIndicator
+      value: 
+      objectReference: {fileID: 1957964602}
     - target: {fileID: 7298473912298103450, guid: 34d9b55fa170a444bb86050513388636,
         type: 3}
       propertyPath: m_AnchorMax.y

--- a/Drawn to Death/Assets/Level 3.unity
+++ b/Drawn to Death/Assets/Level 3.unity
@@ -37817,6 +37817,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7246638093219242156, guid: 34d9b55fa170a444bb86050513388636,
+        type: 3}
+      propertyPath: playerIndicator
+      value: 
+      objectReference: {fileID: 862424960}
     - target: {fileID: 7298473912298103450, guid: 34d9b55fa170a444bb86050513388636,
         type: 3}
       propertyPath: m_AnchorMax.y

--- a/Drawn to Death/Assets/Prefabs/Player.prefab
+++ b/Drawn to Death/Assets/Prefabs/Player.prefab
@@ -403,8 +403,8 @@ MonoBehaviour:
   dashCooldown: 1
   dashBar: {fileID: 0}
   animator: {fileID: 0}
-  recallCooldown: 8
-  allyHealPercentage: 0.5
+  recallCooldown: 15
+  allyHealPercentage: 0.3
   allyStrModifier: 2
   allySpdModifier: 2
   allyAtkSpdModifier: 0.5
@@ -426,8 +426,8 @@ MonoBehaviour:
   oodlerCooldown: 0
   pauseInput: 0
   controls:
-    m_Name: 
-    m_Id: 
+    m_Name: Controls
+    m_Id: d6522f7b-7175-4fd6-b541-8dacee39d512
     m_Asset: {fileID: 0}
     m_Actions: []
     m_Bindings: []
@@ -549,7 +549,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 632ae7eb1d4ce49d38a1e38ee7efe7c5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  guid: 791ee1f6cd677ce9-d530cff6fd9da580
+  guid: 021dfcc71e87913a-5f1c14cbcf88f80a
 --- !u!61 &3786005922980315812
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -642,6 +642,70 @@ MonoBehaviour:
       m_Calls: []
     m_ActionId: 8e9b5724-f769-44ae-ad3f-56457a621108
     m_ActionName: Player/LifeSteal[/Mouse/rightButton,/DualShock4GamepadHID/buttonNorth]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 091d92e6-35fc-40c2-a76b-f438a7c085dd
+    m_ActionName: Player/Escape[/Keyboard/escape]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 4455e10b-e11c-439c-83f4-5dcb982fa9d4
+    m_ActionName: Player/SkipText[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 9c7a8b87-eeb6-4c55-8d81-7c872a1d68e4
+    m_ActionName: Player/ReloadDialogue[/Keyboard/leftBracket]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: a0a15ac6-638a-4e31-bc32-868237b1f4b0
+    m_ActionName: Player/PreviousDialogue[/Keyboard/rightBracket]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 0fb36e47-6e8b-47be-a354-b886271d7aed
+    m_ActionName: UI/Escape[/Keyboard/escape]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: e633c107-6c72-4f32-b1b8-24d681061c6f
+    m_ActionName: UI/Navigate[/Keyboard/w,/Keyboard/upArrow,/Keyboard/s,/Keyboard/downArrow,/Keyboard/a,/Keyboard/leftArrow,/Keyboard/d,/Keyboard/rightArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 1061485e-4bd1-43a3-a683-86b7b0d10445
+    m_ActionName: UI/Submit[/Keyboard/enter]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: f956b7c1-63fa-4fd6-9149-b33fb65c38db
+    m_ActionName: UI/Cancel[/Keyboard/escape]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: febd2d75-1c17-49da-88c2-804d2c6fa99d
+    m_ActionName: UI/Point[/Mouse/position]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: ce0020f1-c29b-4ffe-ad33-bf3a170e5f5b
+    m_ActionName: UI/Click[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: e7ea4dd1-9905-4024-96aa-46c9c0e6c02a
+    m_ActionName: UI/ScrollWheel[/Mouse/scroll]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 836fc0cc-1e92-47bf-8bea-f4c86404b0e5
+    m_ActionName: UI/MiddleClick[/Mouse/middleButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 55f5db70-ad2b-43ca-ac0e-1e16c17b812a
+    m_ActionName: UI/RightClick[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 41e749f9-7458-4a4c-9c3d-e36e4c694525
+    m_ActionName: UI/TrackedDevicePosition
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 918f9f9d-8227-473b-8ba7-9a0a58e56dda
+    m_ActionName: UI/TrackedDeviceOrientation
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 7a718920-74f9-4ee7-adc7-a9fbb778caaf
+    m_ActionName: UI/ScrollFaster[/Mouse/leftButton]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: Player
@@ -801,7 +865,8 @@ MonoBehaviour:
   attackCooldown: 0.5
   reviveRadius: 10
   reviveCap: 50
-  reviveCooldown: 8
+  reviveCooldown: 7
+  OutOfCombatCooldownBoost: 5
   targetDistance: 50
   reviveBar: {fileID: 0}
   activatedReviveNotifier: 0

--- a/Drawn to Death/Assets/Prefabs/Player.prefab
+++ b/Drawn to Death/Assets/Prefabs/Player.prefab
@@ -403,10 +403,14 @@ MonoBehaviour:
   dashCooldown: 1
   dashBar: {fileID: 0}
   animator: {fileID: 0}
-  weapon: {fileID: 0}
+  recallCooldown: 8
+  allyHealPercentage: 0.5
+  allyStrModifier: 2
+  allySpdModifier: 2
+  allyAtkSpdModifier: 0.5
+  allyBuffDuration: 5
   pencil: {fileID: 3034122452498883460}
   recallBar: {fileID: 0}
-  allyHealPercentage: 0.5
   animationDone: 1
   timelinePlaying: 0
   health: 100
@@ -416,10 +420,17 @@ MonoBehaviour:
   abilityDamageReduction: 0.4
   hud: {fileID: 0}
   pauseUi: {fileID: 0}
+  volumeControllerObject: {fileID: 0}
   CameraReference: {fileID: 1320437566207600155}
   HealthBarReference: {fileID: 0}
   oodlerCooldown: 0
   pauseInput: 0
+  controls:
+    m_Name: 
+    m_Id: 
+    m_Asset: {fileID: 0}
+    m_Actions: []
+    m_Bindings: []
   eraserObject: {fileID: 4163747329736801976}
   armsObject: {fileID: 3966632181802528408}
   isGamepad: 0

--- a/Drawn to Death/Assets/Prefabs/UI/HUD/Bars/Rally.prefab
+++ b/Drawn to Death/Assets/Prefabs/UI/HUD/Bars/Rally.prefab
@@ -238,6 +238,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1678241881349738123}
     m_Modifications:
+    - target: {fileID: 4258023302423247281, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: indicatorColor.b
+      value: 0.25490198
+      objectReference: {fileID: 0}
+    - target: {fileID: 4258023302423247281, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: indicatorColor.g
+      value: 0.90588236
+      objectReference: {fileID: 0}
+    - target: {fileID: 4258023302423247281, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: indicatorColor.r
+      value: 0.8156863
+      objectReference: {fileID: 0}
     - target: {fileID: 4489987216564384996, guid: 55646472fc1f45d4f84dfc8cc49a3009,
         type: 3}
       propertyPath: m_Name
@@ -357,6 +372,51 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4489987216987300054, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.252047
+      objectReference: {fileID: 0}
+    - target: {fileID: 4489987216987300054, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.9056604
+      objectReference: {fileID: 0}
+    - target: {fileID: 4489987216987300054, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.8136536
+      objectReference: {fileID: 0}
+    - target: {fileID: 7397770124127545928, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: low.b
+      value: 0.19464225
+      objectReference: {fileID: 0}
+    - target: {fileID: 7397770124127545928, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: low.g
+      value: 0.509434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7397770124127545928, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: low.r
+      value: 0.46581826
+      objectReference: {fileID: 0}
+    - target: {fileID: 7397770124127545928, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: high.b
+      value: 0.25490198
+      objectReference: {fileID: 0}
+    - target: {fileID: 7397770124127545928, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: high.g
+      value: 0.90588236
+      objectReference: {fileID: 0}
+    - target: {fileID: 7397770124127545928, guid: 55646472fc1f45d4f84dfc8cc49a3009,
+        type: 3}
+      propertyPath: high.r
+      value: 0.8156863
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 55646472fc1f45d4f84dfc8cc49a3009, type: 3}

--- a/Drawn to Death/Assets/Prefabs/UI/HUD/HUD.prefab
+++ b/Drawn to Death/Assets/Prefabs/UI/HUD/HUD.prefab
@@ -1265,21 +1265,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1885411055184726828, guid: ca2b59e97f7f73b43922ec1a3d49a949,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.44313726
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885411055184726828, guid: ca2b59e97f7f73b43922ec1a3d49a949,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.89411765
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885411055184726828, guid: ca2b59e97f7f73b43922ec1a3d49a949,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.50980395
-      objectReference: {fileID: 0}
     - target: {fileID: 1885411055523821244, guid: ca2b59e97f7f73b43922ec1a3d49a949,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -1289,36 +1274,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4814304517932532146, guid: ca2b59e97f7f73b43922ec1a3d49a949,
-        type: 3}
-      propertyPath: low.b
-      value: 0.26666668
-      objectReference: {fileID: 0}
-    - target: {fileID: 4814304517932532146, guid: ca2b59e97f7f73b43922ec1a3d49a949,
-        type: 3}
-      propertyPath: low.g
-      value: 0.50980395
-      objectReference: {fileID: 0}
-    - target: {fileID: 4814304517932532146, guid: ca2b59e97f7f73b43922ec1a3d49a949,
-        type: 3}
-      propertyPath: low.r
-      value: 0.2784314
-      objectReference: {fileID: 0}
-    - target: {fileID: 4814304517932532146, guid: ca2b59e97f7f73b43922ec1a3d49a949,
-        type: 3}
-      propertyPath: high.b
-      value: 0.44313726
-      objectReference: {fileID: 0}
-    - target: {fileID: 4814304517932532146, guid: ca2b59e97f7f73b43922ec1a3d49a949,
-        type: 3}
-      propertyPath: high.g
-      value: 0.89411765
-      objectReference: {fileID: 0}
-    - target: {fileID: 4814304517932532146, guid: ca2b59e97f7f73b43922ec1a3d49a949,
-        type: 3}
-      propertyPath: high.r
-      value: 0.50980395
       objectReference: {fileID: 0}
     - target: {fileID: 6178827491331019732, guid: ca2b59e97f7f73b43922ec1a3d49a949,
         type: 3}

--- a/Drawn to Death/Assets/Scripts/Attack.cs
+++ b/Drawn to Death/Assets/Scripts/Attack.cs
@@ -41,6 +41,7 @@ public class Attack : MonoBehaviour
     public float reviveRadius;
     public int reviveCap;
     public float reviveCooldown = 0f;
+    [Min(1f)] public float OutOfCombatCooldownBoost = 5f;
     public float targetDistance = 100f;
     public CooldownTimer reviveTimer;
     public Slider reviveBar;
@@ -187,10 +188,13 @@ public class Attack : MonoBehaviour
     public void CheckRevive()
     {
         //Revive Timer
-        reviveTimer.Update();
-        
+        if (reviveTimer.IsOnCooldown() && BasicMusicScript.instance.GetIntensity() < 1f)
+            reviveTimer.Update(OutOfCombatCooldownBoost);
+        else
+            reviveTimer.Update();
+
         // if revive is at max cooldown, flash the notifier
-         if(reviveTimer.IsUseable() && !activatedReviveNotifier){
+        if (reviveTimer.IsUseable() && !activatedReviveNotifier){
             var temp1 = reviveNotifier.color;
             temp1.a = 1f;
             reviveNotifier.color = temp1;

--- a/Drawn to Death/Assets/Scripts/BasicMusicScript.cs
+++ b/Drawn to Death/Assets/Scripts/BasicMusicScript.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 
 public class BasicMusicScript : MonoBehaviour
 {
-    private FMOD.Studio.EventInstance instance;
+    public static BasicMusicScript instance;
+    private FMOD.Studio.EventInstance eventInstance;
 
     public FMODUnity.EventReference fmodEvent;
 
@@ -17,22 +18,31 @@ public class BasicMusicScript : MonoBehaviour
     [SerializeField] [Range(0f, 30f)]
     private float intensityPerEnemy;
 
+    private void Awake()
+    {
+        if (instance != null)
+        {
+            Debug.LogError("Found more than one Basic Music Script in the scene");
+        }
+        instance = this;
+    }
+
     // Start is called before the first frame update
     void Start()
     {
-        instance = FMODUnity.RuntimeManager.CreateInstance(fmodEvent);
-        instance.start();
+        eventInstance = FMODUnity.RuntimeManager.CreateInstance(fmodEvent);
+        eventInstance.start();
         InvokeRepeating("UpdateIntensity", 0f, 2f); //Update the music intensity every 2 seconds
     }
 
     // Update is called once per frame
     void Update()
     {
-        instance.setParameterByName("Intensity", intensity);
+        eventInstance.setParameterByName("Intensity", intensity);
     }
 
     private void OnDestroy() {
-        instance.stop(0);
+        eventInstance.stop(0);
     }
 
     public void setIntensity(float value)
@@ -61,5 +71,10 @@ public class BasicMusicScript : MonoBehaviour
     public void UpdateIntensity()
     {
         if (autoUpdate) { setIntensity(CalculateIntensity()); }
+    }
+
+    public float GetIntensity()
+    {
+        return intensity;
     }
 }

--- a/Drawn to Death/Assets/Scripts/CooldownTimer.cs
+++ b/Drawn to Death/Assets/Scripts/CooldownTimer.cs
@@ -38,12 +38,12 @@ public class CooldownTimer
         return !(active || onCooldown);
     }
 
-    public void Update()
+    public void Update(float timeModifier = 1f)
     {
         //Update the timer if it is not usable 
         if (!IsUseable())
         {
-            timer += Time.deltaTime;
+            timer += Time.deltaTime * timeModifier;
 
             //Check if active state is over -> start the cooldown
             if (active && timer >= activeduration)

--- a/Drawn to Death/Assets/Scripts/EnemyScripts/EnemyAI.cs
+++ b/Drawn to Death/Assets/Scripts/EnemyScripts/EnemyAI.cs
@@ -47,7 +47,6 @@ public abstract class EnemyAI : MonoBehaviour
     public CooldownTimer slowedTimer;
     public CooldownTimer buffTimer;
     public float slowDuration;
-    public float buffDuration;
     public bool buffed = false;
 
     [Header("References")]
@@ -123,7 +122,7 @@ public abstract class EnemyAI : MonoBehaviour
         invincibilityTimer2 = new CooldownTimer(0f, invincibilityDuration);
         attackTimer = new CooldownTimer(attackCooldown, attackDuration);
         slowedTimer = new CooldownTimer(0.1f, slowDuration);
-        buffTimer = new CooldownTimer(0.1f, buffDuration);
+        buffTimer = new CooldownTimer(0.1f, playerMovement.allyBuffDuration);
         invincibilityTimerOodler = new CooldownTimer(oodlerInvincibilityDuration * 0.5f, oodlerInvincibilityDuration * 0.5f);
 
 
@@ -257,8 +256,8 @@ public abstract class EnemyAI : MonoBehaviour
                 if (buffTimer.IsOnCooldown())
                 {
                     buffed = false;
-                    speed /= 2;
-                    damage /= 2;
+                    speed /= playerMovement.allySpdModifier;
+                    damage /= playerMovement.allyStrModifier;
                     attackTimer.SetCooldown(attackCooldown);
                     selfImage.color = Color.white;
                 }

--- a/Drawn to Death/Assets/Scripts/PlayerMovement.cs
+++ b/Drawn to Death/Assets/Scripts/PlayerMovement.cs
@@ -101,7 +101,6 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
     public GameObject volumeControllerObject;
     private VolumeController volumeController;
 
-
     public Animator CameraReference;
     public Animator HealthBarReference;
 
@@ -116,9 +115,6 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
 
     // Pause all input besides escape
     public bool pauseInput = false;
-
-   
-   
 
     //additional scripts
     [Header("New input system")]

--- a/Drawn to Death/Assets/Scripts/PlayerMovement.cs
+++ b/Drawn to Death/Assets/Scripts/PlayerMovement.cs
@@ -19,8 +19,6 @@ using UnityEngine.InputSystem;
 
 public class PlayerMovement : MonoBehaviour, IDataPersistence
 {
-
-
     //Movement Checks
     [Header("Physics")]
     public float accelerationCoefficient;   //how quickly it speeds up
@@ -29,7 +27,7 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
     public float speedModifier;             //modifiers applied to the player (affects maxVelocity)
 
     //Dash
-    [Header("Dash Options")]
+    [Header("Dash")]
     public bool dashEnabled;
     public float dashBoost;
     public float dashCooldown;
@@ -42,16 +40,24 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
     //Animations
     [HideInInspector] public Animator animator;
     private SpriteRenderer sprite;
-    public Attack weapon;
+    public Attack weapon { get; private set; }
 
     //Recall
-    //private float recallDuration = 115f/60f;
+    [Header("Recall")]
+    private float recallDuration = 115f/60f; 
+    public float recallCooldown;
+    [Range(0, 1)] public float allyHealPercentage;
+    public float allyStrModifier;
+    public float allySpdModifier;
+    public float allyAtkSpdModifier;
+    public float allyBuffDuration;
+
     [SerializeField] private SpriteRenderer pencil;
     private GameObject[] enemies;
     public CooldownTimer recallTimer;
     public UnityEngine.UI.Slider recallBar;
     private CooldownBarBehaviour recallCooldownBar;
-    public float allyHealPercentage;
+    
     
     private UnityEngine.UI.Image recallNotifier;
     private bool activatedRecallNotifier = false;
@@ -143,15 +149,14 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
         health = maxHealth;
         dashTimer = new CooldownTimer(dashCooldown, dashBoost / friction);
         invincibilityTimer = new CooldownTimer(0f, invincibilityDuration);
-        recallTimer = new CooldownTimer(0, 0);
+        recallTimer = new CooldownTimer(recallCooldown, recallDuration);
         lifestealEndTimer = new CooldownTimer(0.1f, 0.532f);
 
         dashCooldownBar = new CooldownBarBehaviour(dashBar, dashCooldown);
-        recallCooldownBar = new CooldownBarBehaviour(recallBar, weapon.reviveCooldown);
+        recallCooldownBar = new CooldownBarBehaviour(recallBar, recallCooldown);
 
         dashTimer.Connect(dashCooldownBar);
         recallTimer.Connect(recallCooldownBar);
-        weapon.reviveTimer.Couple(recallTimer);
 
         dashNotifier = dashBar.transform.parent.GetChild(1).GetComponent<UnityEngine.UI.Image>();
         recallNotifier = recallBar.transform.parent.GetChild(1).GetComponent<UnityEngine.UI.Image>();
@@ -164,12 +169,7 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
         playerInput = GetComponent<PlayerInput>();
 
         playerarms = new PlayerArms(eraserObject, gameObject, armsObject, playerInput, this);
-        
-       
-
     }
-
- 
 
     public void OnDeviceChanged(PlayerInput pi)
     {
@@ -182,41 +182,17 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
         {
             isGamepad = false;
         }
-
     }
-
-    // enable the player controller
-    void Awake()
-    {
-       
-        //controls = new PlayerControlMap();
-        //controls.Enable();
-        //controls.Player.Move.performed += value =>
-        //{
-
-        //    // there is a current bug with this method resulting in the controller being slightly slower than mouse and keyboard when moving
-        //    acceleration= value.ReadValue<Vector2>()*accelerationCoefficient;
-        //};
-
-        //controls.Player.Aim.performed += value2 =>
-        //{
-        //    aimDirection = value2.ReadValue<Vector2>();
-          
-        //};
-    }
-    
-
 
     // Update is called once per frame
     void Update()
     {
-
         acceleration = playerInput.actions["Move"].ReadValue<Vector2>()*accelerationCoefficient;
         aimDirection = playerInput.actions["Aim"].ReadValue<Vector2>();
 
         playerarms.FrameUpdate(aimDirection);
         dashTimer.Update();
-        //recallTimer.Update();
+        recallTimer.Update();
         invincibilityTimer.Update();
         lifestealEndTimer.Update();
 
@@ -271,7 +247,7 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
         }
 
         // disable movement if player is recalling
-        if (weapon.reviveTimer.IsActive())
+        if (weapon.reviveTimer.IsActive() || recallTimer.IsActive())
         {
             acceleration.x = 0;
             acceleration.y = 0;
@@ -342,7 +318,7 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
                 temp.a = 0f;
                 restricted.color = temp;
                 
-                if(weapon.reviveTimer.IsUseable() && !activatedRecallNotifier){
+                if(recallTimer.IsUseable() && !activatedRecallNotifier){
                     var temp1 = recallNotifier.color;
                     temp1.a = 1f;
                     recallNotifier.color = temp1;
@@ -354,7 +330,6 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
         //reset notifier if we have allies or have pressed revive or recall
         if ((playerInput.actions["Rally"].triggered || playerInput.actions["Revive"].triggered) && weapon.GetAllies().Count > 0)
         {
-            weapon.activatedReviveNotifier = false;
             activatedRecallNotifier = false;
         }
 
@@ -364,13 +339,12 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
             var temp = recallNotifier.color;
             temp.a -= 0.01f;
             recallNotifier.color = temp;
-
         }
 
         //If player pressed recall and they are not on cooldown and they have allies, do recall
-        if (weapon.reviveTimer.IsUseable() && CanUseAbility() && playerInput.actions["Rally"].triggered && weapon.GetAllies().Count > 0)
+        if (recallTimer.IsUseable() && CanUseAbility() && playerInput.actions["Rally"].triggered && weapon.GetAllies().Count > 0)
         {
-            weapon.reviveTimer.StartTimer();
+            recallTimer.StartTimer();
             pencil.enabled = false;
             StopMovement();
             FMODUnity.RuntimeManager.PlayOneShot("event:/RallyAbility");
@@ -421,16 +395,12 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
         return v;
     }
 
-   
-
-
     private void ManageAnimations()
     {
-       
         //Set the speed parameter in the animator
         animator.SetFloat("speed", velocity.magnitude);
 
-        if (!inFreezeDialogue() && !timelinePlaying && !weapon.reviveTimer.IsActive())
+        if (!inFreezeDialogue() && !timelinePlaying && !weapon.reviveTimer.IsActive() && !recallTimer.IsActive())
         {
             if (dashTimer.IsActive() && velocity.x != 0f)
             {
@@ -453,19 +423,11 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
                     Vector3 mousePosition = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());
                     sprite.flipX = mousePosition.x < transform.position.x;
                 }
-                
-
             }
-
-            
-
-            
-
         }
 
         //Account for backwards movement
         animator.SetBool("backwards", velocity.x != 0f && (velocity.x < 0f != sprite.flipX));
-        
     }
 
     public void StopMovement()
@@ -486,13 +448,6 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
                return DialogueManager.Instance.dialogueActive;
         }
     }
-
-    public void HandleArms()
-    {
-
-    }
-
-
 
     // Function to run when player takes damage
     public void Damage(float damageTaken, Vector2 knockbackDir = default(Vector2), float knockbackPower = 0f)
@@ -571,13 +526,13 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
     //Some abilities can not be used simultaneously - Check to see if any of those are not active
     public bool CanUseAbility()
     {
-        return !(weapon.reviveTimer.IsActive() || dashTimer.IsActive()) &&
+        return !(weapon.reviveTimer.IsActive() || dashTimer.IsActive() || recallTimer.IsActive()) &&
                !(inFreezeDialogue() || timelinePlaying);
     }
 
     public bool UsingAbility()
     {
-        return weapon.reviveTimer.IsActive() || weapon.lifestealTimer.IsActive() || dashTimer.IsActive() || weapon.lifestealStartTimer.IsActive();
+        return weapon.reviveTimer.IsActive() || recallTimer.IsActive() || weapon.lifestealTimer.IsActive() || dashTimer.IsActive() || weapon.lifestealStartTimer.IsActive();
     }
 
     //Animate the camera zoom
@@ -610,9 +565,9 @@ public class PlayerMovement : MonoBehaviour, IDataPersistence
                     enemy.transform.position = transform.position + total;
                     enemyai.Heal(enemyai.maxHealth * allyHealPercentage);
                     enemyai.buffed = true;
-                    enemyai.speed *= 2;
-                    enemyai.damage *= 2;
-                    enemyai.attackTimer.SetCooldown(enemyai.attackCooldown / 2);
+                    enemyai.speed *= allySpdModifier;
+                    enemyai.damage *= allyStrModifier;
+                    enemyai.attackTimer.SetCooldown(enemyai.attackCooldown * allyAtkSpdModifier);
                 }
             }
         }


### PR DESCRIPTION
- Can now use the Rally & Revive abilities independently
- Added parameters for controlling recall buffs. Adjustable parameters include:
  - Heal percentage
  - Strength/damage modifier
  - Movement speed modifier
  - Attack Speed modifier
  - Buff Duration
- Changed the colour of the recall cooldown bar & indicator
- Added a 5x boost to the revive cooldown speed when out of combat.